### PR TITLE
remove tab characters from yaml files

### DIFF
--- a/lib/helm/chart2json.nix
+++ b/lib/helm/chart2json.nix
@@ -34,7 +34,7 @@ in stdenvNoCC.mkDerivation {
     # join multiple yaml files in jsonl file
     for file in ./resource-*.yaml
     do
-      remarshal -i $file -if yaml -of json >>resources.jsonl
+      (cat $file | tr -d "\t") | (remarshal -if yaml -of json >>resources.jsonl)
     done
 
     # convert jsonl file to json array, remove null values and write to $out


### PR DESCRIPTION
when downloading istio [from](https://storage.googleapis.com/istio-release/releases/1.1.3/charts/index.yaml), templates contains `tab`, so `remarshal` is not able to parse such `yaml` file

```yaml
# Source: istio/charts/security/templates/create-custom-resources-job.yaml

apiVersion: v1	<— tab

kind: ServiceAccount	
metadata:	
  name: istio-security-post-install-account	
  namespace: default	
  labels:	
    app: security	
    chart: security	
    heritage: Tiller	
    release: istio	

```

error:

<img width="848" alt="Screenshot 2019-06-14 at 10 47 06" src="https://user-images.githubusercontent.com/1121938/59497572-03b4df00-8e94-11e9-86b8-e5fc7136753e.png">

example affected file:
<img width="1072" alt="Screenshot 2019-06-14 at 10 17 02" src="https://user-images.githubusercontent.com/1121938/59497606-13ccbe80-8e94-11e9-8d5f-544692214559.png">
